### PR TITLE
Update ZAP Docker Image Source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM owasp/zap2docker-stable AS builder
+FROM zaproxy/zap-stable AS builder
 
 FROM ubuntu:22.04 AS final
 

--- a/agent/zap_agent.py
+++ b/agent/zap_agent.py
@@ -182,7 +182,7 @@ class ZapAgent(agent.Agent, vuln_mixin.AgentReportVulnMixin):
 
         except subprocess.CalledProcessError as e:
             raise RunCommandError(
-                f'An error occurred while running the command {" ".join(command)}'
+                f"An error occurred while running the command {' '.join(command)}"
             ) from e
         except subprocess.TimeoutExpired:
             logger.warning("Java command timed out for command %s", " ".join(command))


### PR DESCRIPTION
This PR updates the ZAP base image in the Dockerfile from `owasp/zap2docker-stable` to `zaproxy/zap-stable`, as the official ZAP images have been moved from OWASP to the SSP and GHCR.