### PR TITLE
fix: Update Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
 FROM zaproxy/zap-stable AS builder
 
-FROM ubuntu:22.04 AS final
+FROM debian:bookworm-slim AS final
 
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y software-properties-common \
-    && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get remove -y python*
 
 # Install necessary packages
 RUN apt-get update && apt-get install -q -y --fix-missing \
@@ -13,7 +10,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	automake \
 	autoconf \
 	gcc g++ \
-	openjdk-11-jdk \
+	openjdk-17-jdk \
 	wget \
 	curl \
 	xmlstarlet \
@@ -23,17 +20,22 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	xterm \
 	net-tools \
 	python-is-python3 \
+    firefox-esr \
     curl \
     python3.11 \
     python3.11-dev \
     python3-pip \
     wireguard-tools \
+    coreutils \
     openresolv \
+    sudo \
     iproute2 \
     xvfb \
     x11vnc \
     virtualenv && \
 	rm -rf /var/lib/apt/lists/*
+
+ENV MOZ_DISABLE_NONLOCAL_CONNECTIONS=1
 
 COPY requirement.txt .
 RUN python3.11 -m virtualenv -p python3.11 /venv
@@ -44,10 +46,20 @@ RUN useradd -u 1000 -d /home/zap -m -s /bin/bash zap
 RUN echo zap:zap | chpasswd
 RUN mkdir /zap && chown zap:zap /zap
 
+RUN usermod -aG sudo zap
+RUN echo "zap ALL=(ALL) NOPASSWD: ALL" | tee /etc/sudoers.d/zap > /dev/null
+
+
 WORKDIR /zap
 
 #Change to the zap user so things get done as the right person (apart from copy)
 USER zap
+
+COPY requirement.txt .
+RUN python3.11 -m virtualenv -p python3.11 /home/zap/venv
+RUN /home/zap/venv/bin/python3.11 -m pip install --upgrade pip
+RUN /home/zap/venv/bin/python3.11 -m pip install -r requirement.txt
+
 
 RUN mkdir /home/zap/.vnc
 
@@ -56,14 +68,15 @@ COPY --from=builder --chown=1000:1000 /zap .
 COPY  --from=builder --chown=1000:1000 /zap/webswing /zap/webswing
 
 ARG TARGETARCH
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-$TARGETARCH
-ENV PATH /venv/bin:$JAVA_HOME/bin:/zap/:$PATH
-ENV ZAP_PATH /zap/zap.sh
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-$TARGETARCH
+ENV PATH=/home/zap/venv/bin:/venv/bin:$JAVA_HOME/bin:/zap/:$PATH
+ENV ZAP_PATH=/zap/zap.sh
+
 
 # Default port for use with health check
-ENV ZAP_PORT 8080
-ENV IS_CONTAINERIZED true
-ENV HOME /home/zap/
+ENV ZAP_PORT=8080
+ENV IS_CONTAINERIZED=true
+ENV HOME=/home/zap/
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
@@ -73,16 +86,33 @@ COPY --from=builder --chown=1000:1000 /root/.ZAP/policies /root/.ZAP/policies/
 COPY --from=builder --chown=1000:1000 /home/zap/.ZAP_D/scripts /home/zap/.ZAP_D/scripts/
 COPY --from=builder --chown=1000:1000 /home/zap/.xinitrc /home/zap/
 
-RUN chmod a+x /home/zap/.xinitrc
+RUN echo "zap2docker-stable" > /zap/container && \
+    chmod a+x /home/zap/.xinitrc
 
 HEALTHCHECK CMD curl --silent --output /dev/null --fail http://localhost:$ZAP_PORT/ || exit 1
 
-USER root
 
-RUN mkdir -p /app/agent
+RUN sudo mkdir -p /app/agent
 ENV PYTHONPATH=/app
 COPY agent /app/agent
 COPY ostorlab.yaml /app/agent/ostorlab.yaml
 WORKDIR /app
 RUN mkdir -p /zap/wrk
+
+USER zap
+
+# Switch to root user for permission changes
+USER root
+
+# Set permissions for /zap and /home/zap directories
+RUN chown -R zap:zap /zap && \
+    chmod -R 777 /zap && \
+    chmod -R 777 /home/zap
+
+# Set /zap as the working directory
+WORKDIR /zap
+
+# Switch back to the zap user
+USER zap
+
 CMD ["/venv/bin/python3.11", "/app/agent/zap_agent.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	net-tools \
 	python-is-python3 \
     firefox-esr \
-    curl \
     python3.11 \
     python3.11-dev \
     python3-pip \
@@ -87,13 +86,9 @@ WORKDIR /app
 RUN mkdir -p /zap/wrk
 
 # Set permissions for /app /zap and /home/zap directories
-RUN chown -R zap:zap /zap && \
-    chmod -R 777 /zap && \
-    chmod -R 777 /app && \
-    chmod -R 777 /home/zap
-
-WORKDIR /app
+RUN chown -R zap:zap /zap /app /home/zap && \
+    chmod -R 700 /zap /app /home/zap
 
 USER zap
 
-CMD ["/venv/bin/python3.11", "/app/agent/zap_agent.py"]
+CMD ["/home/zap/venv/bin/python3.11", "/app/agent/zap_agent.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,16 +86,14 @@ COPY ostorlab.yaml /app/agent/ostorlab.yaml
 WORKDIR /app
 RUN mkdir -p /zap/wrk
 
-# Set permissions for /zap and /home/zap directories
+# Set permissions for /app /zap and /home/zap directories
 RUN chown -R zap:zap /zap && \
     chmod -R 777 /zap && \
     chmod -R 777 /app && \
     chmod -R 777 /home/zap
 
-# Set /zap as the working directory
-WORKDIR /zap
+WORKDIR /app
 
-# Switch back to the zap user
 USER zap
 
 CMD ["/venv/bin/python3.11", "/app/agent/zap_agent.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 
 RUN useradd -u 1000 -d /home/zap -m -s /bin/bash zap
 RUN echo zap:zap | chpasswd
-RUN mkdir /zap && chown zap:zap /zap
+RUN mkdir /zap
 
 WORKDIR /zap
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,10 +37,7 @@ RUN useradd -u 1000 -d /home/zap -m -s /bin/bash zap
 RUN echo zap:zap | chpasswd
 RUN mkdir /zap && chown zap:zap /zap
 
-# Switch to root user for permission changes
 WORKDIR /zap
-
-
 
 #Change to the zap user so things get done as the right person (apart from copy)
 USER zap
@@ -76,8 +73,7 @@ COPY --from=builder --chown=1000:1000 /root/.ZAP/policies /root/.ZAP/policies/
 COPY --from=builder --chown=1000:1000 /home/zap/.ZAP_D/scripts /home/zap/.ZAP_D/scripts/
 COPY --from=builder --chown=1000:1000 /home/zap/.xinitrc /home/zap/
 
-RUN echo "zap2docker-stable" > /zap/container && \
-    chmod a+x /home/zap/.xinitrc
+RUN chmod a+x /home/zap/.xinitrc
 
 HEALTHCHECK CMD curl --silent --output /dev/null --fail http://localhost:$ZAP_PORT/ || exit 1
 

--- a/requirement.txt
+++ b/requirement.txt
@@ -2,7 +2,7 @@ ostorlab[agent]
 rich
 markdownify
 pyyaml
-python-owasp-zap-v2.4
+zaproxy
 tenacity
 awscli
 urllib3


### PR DESCRIPTION
## PR Description

This PR addresses issues from the previous update related to the image changes from `owasp/zap2docker-stable` to `zaproxy/zap-stable`. Several improvements and fixes have been made:

### Changes:
- **Java Version Update**: The image now uses **Java 17** instead of Java 11.
- **Firefox ESR Installation**: 
  - Firefox ESR couldn't be installed directly via `apt` in ubuntu.
  - The `snap` version of Firefox also presented issues with `zap`.
  - To resolve this, we now use a **Debian-based image** to install Firefox ESR from `apt` successfully.
- **User Permissions**: 
  - The image now runs as the `zap` user instead of `root`, as Firefox ESR does not work under the `root` user.
- **Dependency Updates**: 
  - The requirement packages have been updated to use **`zaproxy`** instead of `python-owasp-zap-v2.4`.

agent build successfully:
![build](https://github.com/user-attachments/assets/4c927853-2b48-4438-996c-3c9623a47758)

scan done successfully:
![scan_done](https://github.com/user-attachments/assets/9ff56055-6ac1-42d9-aca2-045b92680532)

Vulnerabilities listed successfully:
![Vulnerabilities_listed_successfully](https://github.com/user-attachments/assets/28715fbd-efb7-49a0-bae2-8fff05c49485)
