### PR TITLE
fix: Simplify Duplicate Findings by Updating Target URI

### DIFF
--- a/agent/result_parser.py
+++ b/agent/result_parser.py
@@ -45,7 +45,7 @@ def _build_technical_detail(
 ) -> str:
     """Build the technical detail markdown content."""
     if "header not set" in title.lower():
-        technical_detail = f"{title} at {target}"
+        technical_detail = f"{title} at {uri}"
     else:
         technical_detail = f"""{header}
 

--- a/tests/result_parser_test.py
+++ b/tests/result_parser_test.py
@@ -42,5 +42,5 @@ def testParseResults_whenMissingHeader_yieldsValidVulnerabilities(
     assert len(vulnz) == 23
     assert (
         vulnz[0].technical_detail
-        == "Strict-Transport-Security Header Not Set at https://www.google.com"
+        == "Strict-Transport-Security Header Not Set at https://www.google.com/default"
     )


### PR DESCRIPTION
This update ensures each security finding is uniquely identified, even when multiple findings share the same domain but have different URIs.
