### PR TITLE
fix: Apply url-regex matching on the targets from zap.

### DIFF
--- a/agent/result_parser.py
+++ b/agent/result_parser.py
@@ -2,7 +2,8 @@
 
 import json
 import dataclasses
-from typing import Dict, Any
+import re
+from typing import Any
 
 from markdownify import markdownify as md
 from ostorlab.agent.kb import kb
@@ -99,7 +100,7 @@ class Vulnerability:
     dna: str
 
 
-def parse_results(results: Dict):
+def parse_results(results: dict[str, Any], scope_urls_regex: str | None = None):
     """Parses JSON generated Zap results and yield vulnerability entries.
 
     Args:
@@ -110,6 +111,9 @@ def parse_results(results: Dict):
     """
     for site in results.get("site", []):
         target = site.get("@name")
+        if scope_urls_regex is not None and re.match(scope_urls_regex, target) is None:
+            continue
+
         host = site.get("@host")
         for alert in site.get("alerts"):
             title = alert.get("name")

--- a/agent/zap_agent.py
+++ b/agent/zap_agent.py
@@ -116,7 +116,9 @@ class ZapAgent(agent.Agent, vuln_mixin.AgentReportVulnMixin):
 
     def _emit_results(self, results: dict) -> None:
         """Parses results and emits vulnerabilities."""
-        for vuln in result_parser.parse_results(results):
+        for vuln in result_parser.parse_results(
+            results=results, scope_urls_regex=self._scope_urls_regex
+        ):
             self.report_vulnerability(
                 entry=vuln.entry,
                 technical_detail=vuln.technical_detail,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def test_agent():
 def test_agent_with_url_scope():
     with (pathlib.Path(__file__).parent.parent / "ostorlab.yaml").open() as yaml_o:
         definition = agent_definitions.AgentDefinition.from_yaml(yaml_o)
-        definition.args[3]["value"] = "([a-zA-Z]+://ostorlab.co/?.*)"
+        definition.args[3]["value"] = "([a-zA-Z0-9]+://(www.)?ostorlab.co/?.*)"
         settings = runtime_definitions.AgentSettings(
             key="agent/ostorlab/zap",
             bus_url="NA",
@@ -94,7 +94,7 @@ def test_agent_with_url_scope():
 def test_agent_with_proxy() -> zap_agent.ZapAgent:
     with (pathlib.Path(__file__).parent.parent / "ostorlab.yaml").open() as yaml_o:
         definition = agent_definitions.AgentDefinition.from_yaml(yaml_o)
-        definition.args[3]["value"] = "([a-zA-Z]+://ostorlab.co/?.*)"
+        definition.args[3]["value"] = "([a-zA-Z0-9]+://(www.)?ostorlab.co/?.*)"
         settings = runtime_definitions.AgentSettings(
             key="agent/ostorlab/zap",
             bus_url="NA",

--- a/tests/zap-output-with-multiple-targets.json
+++ b/tests/zap-output-with-multiple-targets.json
@@ -1,0 +1,81 @@
+{
+	"@version": "2.11.1",
+	"@generated": "Tue, 29 Mar 2022 11:25:42",
+	"site":[ 
+		{
+			"@name": "https://www.ostorlab.co",
+			"@host": "www.google.com",
+			"@port": "443",
+			"@ssl": "true",
+			"alerts": [ 
+				{
+					"pluginid": "10028",
+					"alertRef": "10028",
+					"alert": "Open Redirect",
+					"name": "Open Redirect",
+					"riskcode": "3",
+					"confidence": "2",
+					"riskdesc": "High (Medium)",
+					"desc": "<p>Open redirects are one of the OWASP 2010 Top Ten vulnerabilities. This check looks at user-supplied input in query string parameters and POST data to identify where open redirects might be possible. Open redirects occur when an application allows user-supplied input (e.g. http://nottrusted.com) to control an offsite redirect. This is generally a pretty accurate way to find where 301 or 302 redirects could be exploited by spammers or phishing attacks.</p><p></p><p>For example an attacker could supply a user with the following link: http://example.com/example.php?url=http://malicious.example.com.</p>",
+					"instances":[ 
+						{
+							"uri": "https://www.ostorlab.com/url?q=https://policies.google.com/privacy%3Fhl%3Dfr-MA%26fg%3D1&sa=U&usg=AOvVaw0g_jc-KYZ4RUoufhMKiYyz&ved=0ahUKEwivxPDLmuv2AhXE4IUKHZERCIQQ8awCCA0",
+							"method": "GET",
+							"param": "q",
+							"attack": "",
+							"evidence": ""
+						}
+					],
+					"count": "2",
+					"solution": "<p>To avoid the open redirect vulnerability, parameters of the application script/program must be validated before sending 302 HTTP code (redirect) to the client browser. Implement safe redirect functionality that only redirects to relative URI's, or a list of trusted domains</p>",
+					"otherinfo": "<p>The 301 or 302 response to a request for the following URL appeared to contain user input in the location header:</p><p></p><p>https://www.google.com/url?q=https://policies.google.com/privacy%3Fhl%3Dfr-MA%26fg%3D1&sa=U&usg=AOvVaw0g_jc-KYZ4RUoufhMKiYyz&ved=0ahUKEwivxPDLmuv2AhXE4IUKHZERCIQQ8awCCA0</p><p></p><p>The user input found was:</p><p></p><p>q=https://policies.google.com/privacy?hl=fr-MA&fg=1</p><p></p><p>The context was:</p><p></p><p>https://policies.google.com/privacy?hl=fr-MA&fg=1</p>",
+					"reference": "<p>https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html</p><p>https://cwe.mitre.org/data/definitions/601.html</p>",
+					"cweid": "601",
+					"wascid": "38",
+					"sourceid": "1218"
+				}
+			]
+		},
+		{
+			"@name": "https://www.google.com",
+			"@host": "www.google.com",
+			"@port": "443",
+			"@ssl": "true",
+			"alerts": [ 
+				{
+					"pluginid": "10028",
+					"alertRef": "10028",
+					"alert": "Open Redirect",
+					"name": "Open Redirect",
+					"riskcode": "3",
+					"confidence": "2",
+					"riskdesc": "High (Medium)",
+					"desc": "<p>Open redirects are one of the OWASP 2010 Top Ten vulnerabilities. This check looks at user-supplied input in query string parameters and POST data to identify where open redirects might be possible. Open redirects occur when an application allows user-supplied input (e.g. http://nottrusted.com) to control an offsite redirect. This is generally a pretty accurate way to find where 301 or 302 redirects could be exploited by spammers or phishing attacks.</p><p></p><p>For example an attacker could supply a user with the following link: http://example.com/example.php?url=http://malicious.example.com.</p>",
+					"instances":[ 
+						{
+							"uri": "https://www.google.com/url?q=https://policies.google.com/privacy%3Fhl%3Dfr-MA%26fg%3D1&sa=U&usg=AOvVaw0g_jc-KYZ4RUoufhMKiYyz&ved=0ahUKEwivxPDLmuv2AhXE4IUKHZERCIQQ8awCCA0",
+							"method": "GET",
+							"param": "q",
+							"attack": "",
+							"evidence": ""
+						},
+						{
+							"uri": "https://www.google.com/url?q=https://policies.google.com/terms%3Fhl%3Dfr-MA%26fg%3D1&sa=U&usg=AOvVaw3LU-vlWBv4WomQqSiinRwS&ved=0ahUKEwivxPDLmuv2AhXE4IUKHZERCIQQ8qwCCA4",
+							"method": "GET",
+							"param": "q",
+							"attack": "",
+							"evidence": ""
+						}
+					],
+					"count": "2",
+					"solution": "<p>To avoid the open redirect vulnerability, parameters of the application script/program must be validated before sending 302 HTTP code (redirect) to the client browser. Implement safe redirect functionality that only redirects to relative URI's, or a list of trusted domains</p>",
+					"otherinfo": "<p>The 301 or 302 response to a request for the following URL appeared to contain user input in the location header:</p><p></p><p>https://www.google.com/url?q=https://policies.google.com/privacy%3Fhl%3Dfr-MA%26fg%3D1&sa=U&usg=AOvVaw0g_jc-KYZ4RUoufhMKiYyz&ved=0ahUKEwivxPDLmuv2AhXE4IUKHZERCIQQ8awCCA0</p><p></p><p>The user input found was:</p><p></p><p>q=https://policies.google.com/privacy?hl=fr-MA&fg=1</p><p></p><p>The context was:</p><p></p><p>https://policies.google.com/privacy?hl=fr-MA&fg=1</p>",
+					"reference": "<p>https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html</p><p>https://cwe.mitre.org/data/definitions/601.html</p>",
+					"cweid": "601",
+					"wascid": "38",
+					"sourceid": "1218"
+				}
+			]
+		}
+	]
+}

--- a/tests/zap-test-output.json
+++ b/tests/zap-test-output.json
@@ -3,7 +3,7 @@
 	"@generated": "Tue, 29 Mar 2022 11:25:42",
 	"site":[ 
 		{
-			"@name": "https://www.google.com",
+			"@name": "https://www.ostorlab.co",
 			"@host": "www.google.com",
 			"@port": "443",
 			"@ssl": "true",


### PR DESCRIPTION
The `scope_urls_regex` we currently have only applies to `ostorlab.Messages`, however, the zap scan can also report findings on different targets than those specified in the scan command.
One possible solution would be adding the `-z config` option when running the command & specify some sort of blacklist.. however since we already have the argument & logic that checks, it was added at the step of parsing & reporting directly.